### PR TITLE
add basic UI - text area for store style code, inject test element into dom, add clone option

### DIFF
--- a/src/js/injectelem.js
+++ b/src/js/injectelem.js
@@ -1,0 +1,89 @@
+/* eslint-disable */
+
+export const injectAutomTestEle = (styleContent) => {
+  const automBaseStyles = `
+    .bx-automator-test .bx-slab {
+      position: fixed;
+      top: 0;
+      background-color: rgba(165, 165, 255, 0.85);
+      height: 40px;
+      width: 100vw;
+      z-index: 2147483647;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .bx-automator-test-clone .bx-slab {
+      position: relative;
+      top: 0;
+      height: 40px;
+      width: 100vw;
+    }
+  `;
+
+  // Extract the numeric height value from automBaseStyles
+  const heightMatch = automBaseStyles.match(/height:\s*(\d+(\.\d+)?)/);
+  const heightValue = heightMatch ? parseFloat(heightMatch[1]) : 40;
+
+  // Replace '+pushAmount+' with the height value in styleContent, including the enclosing '
+  const updatedStyleContent =
+    typeof styleContent === "string"
+      ? styleContent.replace(/\'\+pushAmount\+\'/g, parseFloat(heightValue))
+      : "";
+
+  // Check if the element already exists
+  const existingDiv = document.querySelector(".bx-automator-test");
+
+  if (existingDiv) {
+    // Update existing styles
+    const baseStyleElement = existingDiv.querySelector(
+      ".bx-automator-test-base-style",
+    );
+    if (baseStyleElement) {
+      baseStyleElement.textContent = automBaseStyles;
+    }
+
+    const styleElement = existingDiv.querySelector(".bx-automator-test-style");
+    if (styleElement) {
+      styleElement.textContent = updatedStyleContent;
+    }
+  } else {
+    // Create the automator test element
+    const div = document.createElement("div");
+    div.classList.add("bxc", "bx-automator-test");
+    const divClone = document.createElement("div");
+    divClone.classList.add("bxc", "bx-automator-test-clone");
+
+    // Create the slab div element
+    const childDiv = document.createElement("div");
+    childDiv.classList.add("bx-slab");
+    const childDivClone = document.createElement("div");
+    childDivClone.classList.add("bx-slab");
+
+    // Create the text element and center it
+    const textElement = document.createElement("p");
+    textElement.textContent = "Automator testing element";
+    textElement.style.textAlign = "center";
+    childDiv.appendChild(textElement); // Append the text element to the child div
+
+    div.appendChild(childDiv);
+    divClone.appendChild(childDivClone);
+
+    // Create the base stylesheet and set its content
+    const style = document.createElement("style");
+    style.classList.add("bx-automator-test-base-style");
+    style.textContent = automBaseStyles;
+    div.appendChild(style);
+
+    // Create the bx-automator-test stylesheet
+    const style2 = document.createElement("style");
+    style2.classList.add("bx-automator-test-style");
+    style2.textContent = updatedStyleContent;
+    div.appendChild(style2);
+    divClone.appendChild(style2.cloneNode(true));
+
+    // Prepend the div to the body
+    document.body.prepend(div);
+    document.body.prepend(divClone);
+  }
+};

--- a/src/js/injectelem.js
+++ b/src/js/injectelem.js
@@ -19,6 +19,11 @@ export const injectAutomTestEle = (styleContent) => {
       height: 40px;
       width: 100vw;
     }
+    .bx-automator-test p {
+      font-size: 16px;
+      color: black;
+      font-weight: bold;
+    }
   `;
 
   // Extract the numeric height value from automBaseStyles

--- a/src/ui/DevtoolsPanel.tsx
+++ b/src/ui/DevtoolsPanel.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react";
 import ReactDOM from "react-dom/client";
 import { Button, Typography, spacingMap } from "@frontend/wknd-components";
 import { getFixedAndStickySelectors } from "../js/automator";
+import { injectAutomTestEle } from "../js/injectElem";
 import "../css/fonts.scss";
 import "../css/styles.scss";
 
@@ -203,12 +204,89 @@ function DevtoolsPanel() {
               func: getFixedAndStickySelectors,
             },
             (results: any) => {
-              setStyles(parseCSS(results[0].result));
+              const resultText = results[0].result;
+              setStyles(parseCSS(resultText));
+              const textarea = document.getElementById(
+                "styleTextarea",
+              ) as HTMLTextAreaElement;
+              textarea.value = resultText;
             },
           );
         }}
         variant="primary"
       />
+      <Button
+        buttonText={"Clear Styles"}
+        mb={spacingMap.md}
+        onClick={() => {
+          const textarea = document.getElementById(
+            "styleTextarea",
+          ) as HTMLTextAreaElement;
+          textarea.value = "";
+        }}
+        variant="primary"
+      />
+
+      <textarea
+        id="styleTextarea"
+        placeholder="Enter text"
+        style={{ marginBottom: spacingMap.md, width: "100%", height: "150px" }}
+      />
+
+      <Button
+        buttonText={"Full Inject"}
+        mb={spacingMap.md}
+        onClick={() => {
+          const textarea = document.getElementById(
+            "styleTextarea",
+          ) as HTMLTextAreaElement;
+          const styleContent = textarea.value;
+
+          chrome.tabs
+            .query({ active: true, lastFocusedWindow: true })
+            .then((response) => {
+              let tabId = response[0].id;
+
+              return chrome.scripting
+                .executeScript({
+                  target: { tabId: tabId },
+                  func: injectAutomTestEle,
+                  args: [styleContent],
+                })
+                .catch((e) => setShowError(e.message));
+            });
+        }}
+        variant="primary"
+      />
+
+      <Button
+        buttonText={"Inject Stylesheet"}
+        mb={spacingMap.md}
+        onClick={() => {
+          const textarea = document.getElementById(
+            "styleTextarea",
+          ) as HTMLTextAreaElement;
+          const styleContent = textarea.value;
+
+          chrome.tabs
+            .query({ active: true, lastFocusedWindow: true })
+            .then((response) => {
+              let tabId = response[0].id;
+
+              return chrome.scripting
+                .executeScript({
+                  target: { tabId: tabId },
+                  func: injectAutomTestEle,
+                  args: [styleContent],
+                })
+                .catch((e) => setShowError(e.message));
+            });
+        }}
+        variant="primary"
+      />
+
+      <Typography variant="bodyCopy">{devToolsMessage}</Typography>
+      <Typography variant="bodyCopy">{backgroundMessage}</Typography>
     </div>
   );
 }

--- a/src/ui/DevtoolsPanel.tsx
+++ b/src/ui/DevtoolsPanel.tsx
@@ -319,6 +319,10 @@ function DevtoolsPanel() {
             });
         }}
         variant="primary"
+        style={{
+          backgroundColor:
+            buttonText === "Injected - refresh styles" ? "green" : "",
+        }}
       />
 
       <Typography variant="bodyCopy">{devToolsMessage}</Typography>


### PR DESCRIPTION
[JIRA - IPPS-2157](https://wunderkindco.atlassian.net/browse/IPPS-2157) - Create basic UI in the devtools panel

- add text field
- and submit button to push to site


Full details: 
- Added text area for styles to populate from `Get Styles` when clicked
- Added `Clear Styles` button to clear text area
- Added `Inject Test Top Bar` button to inject a pseudo top bar campaign element and prepend to the body
  - If automator top bar already exists, update the stylesheet with the text area content
  - Button text to change to `Injected - Refresh Styles`, revert back if element doesn’t exist (clicking Add Clone will check)
  - Clicking when element already exists will only update styles
- Added `Add Clone` checkbox so live test can better replicate pushdown effects onsite
  - if `Add Clone` checkbox is unchecked and `Injected - Refresh Styles` is clicked, remove the clone element.


Challenges:
- some elements with css top: var( some-variable ) does not get pulled in from Get Styles
- resize listeners isn’t working because of scoping; may need to set up separate function / functionality that is called to the Devtools.tsx instead from within the injectTestElem.js