### PR TITLE
Add functionality to set z-index + recheck button states

### DIFF
--- a/src/js/anchorAdjust.js
+++ b/src/js/anchorAdjust.js
@@ -1,0 +1,33 @@
+/* eslint-disable */
+
+export function updateAnchorPlacement(selector, placement) {
+  const targetElement = document.querySelector(selector);
+  const automatorElement = document.querySelector(".bx-automator-test");
+
+  if (!targetElement || !automatorElement) {
+    console.error("Target element or .bx-automator-test element not found");
+    return;
+  }
+
+  automatorElement.remove();
+
+  switch (placement) {
+    case "prepend":
+      targetElement.prepend(automatorElement);
+      break;
+    case "append":
+      targetElement.append(automatorElement);
+      break;
+    case "before":
+      targetElement.parentNode.insertBefore(automatorElement, targetElement);
+      break;
+    case "after":
+      targetElement.parentNode.insertBefore(
+        automatorElement,
+        targetElement.nextSibling,
+      );
+      break;
+    default:
+      console.error("Invalid placement option");
+  }
+}

--- a/src/js/setZindex.js
+++ b/src/js/setZindex.js
@@ -1,0 +1,35 @@
+/* eslint-disable */
+
+export const setZindex = (zIndexValue) => {
+  if (!zIndexValue) {
+    console.error("z-index value is required");
+    return false; // Return false if no z-index value is provided
+  }
+
+  // Find the .bx-automator-test element
+  const automatorTestElement = document.querySelector(".bx-automator-test");
+
+  if (!automatorTestElement) {
+    console.error(".bx-automator-test element not found");
+    return false; // Return false if the target element doesn't exist
+  }
+
+  // Check if the z-index fix style already exists
+  const existingStyle = document.querySelector(
+    ".bx-automation-zindex-fix-style",
+  );
+  if (existingStyle) {
+    // Update the existing style content
+    existingStyle.textContent = `.bxc.bx-automator-test .bx-slab { z-index: ${zIndexValue}; }`;
+    return true; // Return true if the style was updated
+  } else {
+    // Create a new style element for the z-index fix
+    const style = document.createElement("style");
+    style.classList.add("bx-automation-zindex-fix-style");
+    style.textContent = `.bxc.bx-automator-test .bx-slab { z-index: ${zIndexValue}; }`;
+
+    // Append the style element to the .bx-automator-test element
+    automatorTestElement.appendChild(style);
+    return true; // Return true if the style was added
+  }
+};

--- a/src/ui/DevtoolsPanel.tsx
+++ b/src/ui/DevtoolsPanel.tsx
@@ -332,94 +332,96 @@ function DevtoolsPanel() {
       />
 
       {isExpanded && (
-        <div
-          style={{
-            border: "2px solid blue",
-            padding: "10px",
-            marginBottom: spacingMap.md,
-          }}
-        >
+        <>
           <Typography
             mb={spacingMap.md}
-            style={{ marginBottom: spacingMap.md, fontSize: "20px" }}
+            style={{ fontSize: "20px" }}
             variant="headline"
           >
             Advanced Settings
           </Typography>
-          <Typography
-            mb={spacingMap.md}
-            style={{ marginBottom: "10px", fontSize: "18px" }}
-            variant="bodyCopy"
-          >
-            Anchor Placement Adjustment
-          </Typography>
-          <Typography
-            mb={spacingMap.md}
-            style={{ marginBottom: "5px", fontSize: "14px" }}
-            variant="bodyCopy"
-          >
-            Alternate selector for top bar placement
-          </Typography>
-          <input
-            type="text"
-            className="topBarPlacementSelector"
-            placeholder="Placement Selector ( .header )"
+          <div
             style={{
+              border: "2px solid blue",
+              padding: "10px",
               marginBottom: spacingMap.md,
-              marginRight: "10px",
-              width: "200px",
-              height: "26px",
-            }}
-          />
-          <select
-            className="placementDropdown"
-            style={{
-              marginBottom: spacingMap.md,
-              marginRight: "20px",
-              width: "100px",
-              height: "32px",
             }}
           >
-            <option value="prepend">Prepend</option>
-            <option value="append">Append</option>
-            <option value="before">Before</option>
-            <option value="after">After</option>
-          </select>
-          <Button
-            buttonText={"Update Anchor Placement"}
-            mb={spacingMap.md}
-            onClick={() => {
-              const selector = (
-                document.querySelector(
-                  ".topBarPlacementSelector",
-                ) as HTMLInputElement
-              ).value;
-              const placement = (
-                document.querySelector(
-                  ".placementDropdown",
-                ) as HTMLSelectElement
-              ).value;
+            <Typography
+              mb={spacingMap.md}
+              style={{ marginBottom: "10px", fontSize: "18px" }}
+              variant="bodyCopy"
+            >
+              Anchor Placement Adjustment
+            </Typography>
+            <Typography
+              mb={spacingMap.md}
+              style={{ marginBottom: "5px", fontSize: "14px" }}
+              variant="bodyCopy"
+            >
+              Alternate selector for top bar placement
+            </Typography>
+            <input
+              type="text"
+              className="topBarPlacementSelector"
+              placeholder="Placement Selector ( .header )"
+              style={{
+                marginBottom: spacingMap.md,
+                marginRight: "10px",
+                width: "200px",
+                height: "26px",
+              }}
+            />
+            <select
+              className="placementDropdown"
+              style={{
+                marginBottom: spacingMap.md,
+                marginRight: "20px",
+                width: "100px",
+                height: "32px",
+              }}
+            >
+              <option value="prepend">Prepend</option>
+              <option value="append">Append</option>
+              <option value="before">Before</option>
+              <option value="after">After</option>
+            </select>
+            <Button
+              buttonText={"Update Anchor Placement"}
+              mb={spacingMap.md}
+              onClick={() => {
+                const selector = (
+                  document.querySelector(
+                    ".topBarPlacementSelector",
+                  ) as HTMLInputElement
+                ).value;
+                const placement = (
+                  document.querySelector(
+                    ".placementDropdown",
+                  ) as HTMLSelectElement
+                ).value;
 
-              chrome.tabs
-                .query({ active: true, lastFocusedWindow: true })
-                .then((response) => {
-                  let tabId = response[0].id;
+                chrome.tabs
+                  .query({ active: true, lastFocusedWindow: true })
+                  .then((response) => {
+                    let tabId = response[0].id;
 
-                  return chrome.scripting
-                    .executeScript({
-                      target: { tabId: tabId },
-                      func: updateAnchorPlacement,
-                      args: [selector, placement],
-                    })
-                    .then(() => {
-                      setShowError("");
-                    })
-                    .catch((e) => setShowError(e.message));
-                });
-            }}
-            variant="primary"
-          />
-        </div>
+                    return chrome.scripting
+                      .executeScript({
+                        target: { tabId: tabId },
+                        func: updateAnchorPlacement,
+                        args: [selector, placement],
+                      })
+                      .then(() => {
+                        setShowError("");
+                      })
+                      .catch((e) => setShowError(e.message));
+                  });
+              }}
+              variant="primary"
+            />
+          </div>
+        </>
       )}
 
       <Typography variant="bodyCopy">{devToolsMessage}</Typography>

--- a/src/ui/DevtoolsPanel.tsx
+++ b/src/ui/DevtoolsPanel.tsx
@@ -276,7 +276,6 @@ function DevtoolsPanel() {
           zIndex: 1000,
         }}
       >
-        {/* Reload button fixed to the top-right corner */}
         <Tooltip
           dataQA="tooltip"
           position="bottom-end"
@@ -288,14 +287,14 @@ function DevtoolsPanel() {
             dataQA="button-data-qa"
             icon="SearchCodeIcon"
             onClick={() => {
-              setRotationAngle((prevAngle) => prevAngle + 360); // Increment rotation angle
-              handleReloadClick(); // Call the existing reload logic
+              setRotationAngle((prevAngle) => prevAngle + 360);
+              handleReloadClick();
             }}
             variant="primary"
             style={{
               borderRadius: "50%",
-              transform: `rotate(${rotationAngle}deg)`, // Apply rotation
-              transition: "transform 1s ease-in-out", // Smooth animation
+              transform: `rotate(${rotationAngle}deg)`,
+              transition: "transform 1s ease-in-out",
             }}
           />
         </Tooltip>
@@ -405,7 +404,7 @@ function DevtoolsPanel() {
                 })
                 .then(() => {
                   setButtonText("Injected - refresh styles");
-                  setIsZIndexButtonEnabled(true); // Enable z-index button
+                  setIsZIndexButtonEnabled(true);
                 })
                 .catch((e) => setShowError(e.message));
             });
@@ -430,22 +429,22 @@ function DevtoolsPanel() {
             marginRight: "10px",
             height: "26px",
           }}
-          disabled={!isZIndexButtonEnabled} // Disable input if z-index button is disabled
+          disabled={!isZIndexButtonEnabled}
         />
         <Button
-          buttonText={zIndexButtonText} // Dynamic button text
+          buttonText={zIndexButtonText}
           onClick={() => {
             const zIndexInput = document.getElementById(
               "zIndexInput",
             ) as HTMLInputElement;
             const zIndexValue = zIndexInput.value;
 
-            if (!zIndexValue) {
-              setZIndexError("Add a z-index value"); // Show error if input is empty
+            if (!zIndexValue || isNaN(Number(zIndexValue))) {
+              setZIndexError("Please enter a valid number for z-index");
               return;
             }
 
-            setZIndexError(""); // Clear error if input is valid
+            setZIndexError("");
 
             chrome.tabs
               .query({ active: true, lastFocusedWindow: true })
@@ -460,17 +459,17 @@ function DevtoolsPanel() {
               })
               .then((results) => {
                 if (results[0].result) {
-                  setZIndexButtonText("Update z-index"); // Update button text
-                  setZIndexButtonStyle({ backgroundColor: "green" }); // Change button style
+                  setZIndexButtonText("Update z-index");
+                  setZIndexButtonStyle({ backgroundColor: "green" });
                 } else {
-                  setZIndexError("Failed to set z-index"); // Show error if the operation failed
+                  setZIndexError("Failed to set z-index");
                 }
               })
               .catch((e) => setShowError(e.message));
           }}
           variant="primary"
-          style={zIndexButtonStyle} // Dynamic button style
-          disabled={!isZIndexButtonEnabled} // Disable button if z-index button is disabled
+          style={zIndexButtonStyle}
+          disabled={!isZIndexButtonEnabled}
           dataQA={""}
         />
         {zIndexError && (

--- a/src/ui/DevtoolsPanel.tsx
+++ b/src/ui/DevtoolsPanel.tsx
@@ -348,97 +348,96 @@ function DevtoolsPanel() {
               marginBottom: spacingMap.md,
             }}
           >
-            <Typography
-              mb={spacingMap.md}
-              style={{ marginBottom: "10px", fontSize: "18px" }}
-              variant="bodyCopy"
-            >
-              Anchor Placement Adjustment
-            </Typography>
-            <Typography
-              mb={spacingMap.md}
-              style={{ marginBottom: "5px", fontSize: "14px" }}
-              variant="bodyCopy"
-            >
-              Alternate selector for top bar placement
-            </Typography>
-            <input
-              type="text"
-              className="topBarPlacementSelector"
-              placeholder="Placement Selector ( .header )"
-              style={{
-                marginBottom: spacingMap.md,
-                marginRight: "10px",
-                width: "200px",
-                height: "26px",
-              }}
-            />
-            <select
-              className="placementDropdown"
-              style={{
-                marginBottom: spacingMap.md,
-                marginRight: "20px",
-                width: "100px",
-                height: "32px",
-              }}
-            >
-              <option value="prepend">Prepend</option>
-              <option value="append">Append</option>
-              <option value="before">Before</option>
-              <option value="after">After</option>
-            </select>
-            <Button
-              buttonText={"Update Anchor Placement"}
-              mb={spacingMap.md}
-              onClick={() => {
-                const selector = (
-                  document.querySelector(
-                    ".topBarPlacementSelector",
-                  ) as HTMLInputElement
-                ).value;
-                const placement = (
-                  document.querySelector(
-                    ".placementDropdown",
-                  ) as HTMLSelectElement
-                ).value;
-
-                chrome.tabs
-                  .query({ active: true, lastFocusedWindow: true })
-                  .then((response) => {
-                    let tabId = response[0].id;
-
-                    return chrome.scripting
-                      .executeScript({
-                        target: { tabId: tabId },
-                        func: (sel) => !!document.querySelector(sel),
-                        args: [selector],
-                      })
-                      .then((results) => {
-                        if (results[0].result) {
-                          return chrome.scripting.executeScript({
-                            target: { tabId: tabId },
-                            func: updateAnchorPlacement,
-                            args: [selector, placement],
-                          });
-                        } else {
-                          setAnchorError("Selector does not exist");
-                          throw new Error("Selector does not exist");
-                        }
-                      })
-                      .then(() => {
-                        setShowError("");
-                        setAnchorError("");
-                      })
-                      .catch((e) => setShowError(e.message));
-                  });
-              }}
-              variant="primary"
-            />
-            {anchorError && (
-              <Typography variant="bodyCopy" style={{ color: "red" }}>
-                {anchorError}
+            <div style={{ marginBottom: spacingMap.md }}>
+              <Typography
+                mb={spacingMap.md}
+                style={{ marginBottom: "10px", fontSize: "18px" }}
+                variant="bodyCopy"
+              >
+                Anchor Placement Adjustment
               </Typography>
-            )}
+              <Typography
+                mb={spacingMap.md}
+                style={{ marginBottom: "5px", fontSize: "14px" }}
+                variant="bodyCopy"
+              >
+                Alternate selector for top bar placement
+              </Typography>
+              <input
+                type="text"
+                className="topBarPlacementSelector"
+                placeholder="Placement Selector ( .header )"
+                style={{
+                  marginRight: "10px",
+                  width: "200px",
+                  height: "26px",
+                }}
+              />
+              <select
+                className="placementDropdown"
+                style={{
+                  marginRight: "20px",
+                  width: "100px",
+                  height: "32px",
+                }}
+              >
+                <option value="prepend">Prepend</option>
+                <option value="append">Append</option>
+                <option value="before">Before</option>
+                <option value="after">After</option>
+              </select>
+              <Button
+                buttonText={"Update Anchor Placement"}
+                onClick={() => {
+                  const selector = (
+                    document.querySelector(
+                      ".topBarPlacementSelector",
+                    ) as HTMLInputElement
+                  ).value;
+                  const placement = (
+                    document.querySelector(
+                      ".placementDropdown",
+                    ) as HTMLSelectElement
+                  ).value;
+
+                  chrome.tabs
+                    .query({ active: true, lastFocusedWindow: true })
+                    .then((response) => {
+                      let tabId = response[0].id;
+
+                      return chrome.scripting
+                        .executeScript({
+                          target: { tabId: tabId },
+                          func: (sel) => !!document.querySelector(sel),
+                          args: [selector],
+                        })
+                        .then((results) => {
+                          if (results[0].result) {
+                            return chrome.scripting.executeScript({
+                              target: { tabId: tabId },
+                              func: updateAnchorPlacement,
+                              args: [selector, placement],
+                            });
+                          } else {
+                            setAnchorError("Selector does not exist");
+                            throw new Error("Selector does not exist");
+                          }
+                        })
+                        .then(() => {
+                          setShowError("");
+                          setAnchorError("");
+                        })
+                        .catch((e) => setShowError(e.message));
+                    });
+                }}
+                variant="primary"
+              />
+              {anchorError && (
+                <Typography variant="bodyCopy" style={{ color: "red" }}>
+                  {anchorError}
+                </Typography>
+              )}
+            </div>
           </div>
         </>
       )}

--- a/src/ui/DevtoolsPanel.tsx
+++ b/src/ui/DevtoolsPanel.tsx
@@ -2,7 +2,12 @@
 
 import React, { useEffect, useState } from "react";
 import ReactDOM from "react-dom/client";
-import { Button, Typography, spacingMap } from "@frontend/wknd-components";
+import {
+  Button,
+  Typography,
+  fontSizes,
+  spacingMap,
+} from "@frontend/wknd-components";
 import { getFixedAndStickySelectors } from "../js/automator";
 import { injectAutomTestEle } from "../js/injectElem";
 import { updateAnchorPlacement } from "../js/anchorAdjust";
@@ -315,7 +320,7 @@ function DevtoolsPanel() {
       />
 
       <Button
-        buttonText={`Advanced Settings | ${isExpanded ? "Collapse" : "Expand"}`}
+        buttonText={`Advanced Settings  ${isExpanded ? "  <  Collapse" : "  >  Expand"}`}
         mb={spacingMap.md}
         onClick={() => setIsExpanded(!isExpanded)}
         style={{
@@ -327,16 +332,43 @@ function DevtoolsPanel() {
       />
 
       {isExpanded && (
-        <div style={{ marginBottom: spacingMap.md }}>
+        <div
+          style={{
+            border: "2px solid blue",
+            padding: "10px",
+            marginBottom: spacingMap.md,
+          }}
+        >
+          <Typography
+            mb={spacingMap.md}
+            style={{ marginBottom: spacingMap.md, fontSize: "20px" }}
+            variant="headline"
+          >
+            Advanced Settings
+          </Typography>
+          <Typography
+            mb={spacingMap.md}
+            style={{ marginBottom: "10px", fontSize: "18px" }}
+            variant="bodyCopy"
+          >
+            Anchor Placement Adjustment
+          </Typography>
+          <Typography
+            mb={spacingMap.md}
+            style={{ marginBottom: "5px", fontSize: "14px" }}
+            variant="bodyCopy"
+          >
+            Alternate selector for top bar placement
+          </Typography>
           <input
             type="text"
             className="topBarPlacementSelector"
-            placeholder="Alternative Placement Selector"
+            placeholder="Placement Selector ( .header )"
             style={{
               marginBottom: spacingMap.md,
               marginRight: "10px",
               width: "200px",
-              height: "32px",
+              height: "26px",
             }}
           />
           <select

--- a/src/ui/DevtoolsPanel.tsx
+++ b/src/ui/DevtoolsPanel.tsx
@@ -5,6 +5,7 @@ import ReactDOM from "react-dom/client";
 import { Button, Typography, spacingMap } from "@frontend/wknd-components";
 import { getFixedAndStickySelectors } from "../js/automator";
 import { injectAutomTestEle } from "../js/injectElem";
+import { updateAnchorPlacement } from "../js/anchorAdjust";
 import "../css/fonts.scss";
 import "../css/styles.scss";
 
@@ -172,19 +173,7 @@ function DevtoolsPanel() {
   const [addClone, setAddClone] = useState(true); // set Default checked
   const [addResizeListener, setAddResizeListener] = useState(false);
   const [buttonText, setButtonText] = useState("Inject Test Topbar");
-
-  function handleMessageRequestClick(
-    requestMsg: () => Promise<string>,
-    setMsg: React.Dispatch<React.SetStateAction<string>>,
-  ) {
-    requestMsg()
-      .then((results) => {
-        setMsg(results);
-      })
-      .catch((e) => {
-        setShowError(e as string);
-      });
-  }
+  const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
     console.log("Styles updated", styles);
@@ -324,6 +313,82 @@ function DevtoolsPanel() {
             buttonText === "Injected - refresh styles" ? "green" : "",
         }}
       />
+
+      <Button
+        buttonText={`Advanced Settings | ${isExpanded ? "Collapse" : "Expand"}`}
+        mb={spacingMap.md}
+        onClick={() => setIsExpanded(!isExpanded)}
+        style={{
+          marginBottom: spacingMap.md,
+          marginTop: spacingMap.md,
+          display: "block",
+        }}
+        variant="primary"
+      />
+
+      {isExpanded && (
+        <div style={{ marginBottom: spacingMap.md }}>
+          <input
+            type="text"
+            className="topBarPlacementSelector"
+            placeholder="Alternative Placement Selector"
+            style={{
+              marginBottom: spacingMap.md,
+              marginRight: "10px",
+              width: "200px",
+              height: "32px",
+            }}
+          />
+          <select
+            className="placementDropdown"
+            style={{
+              marginBottom: spacingMap.md,
+              marginRight: "20px",
+              width: "100px",
+              height: "32px",
+            }}
+          >
+            <option value="prepend">Prepend</option>
+            <option value="append">Append</option>
+            <option value="before">Before</option>
+            <option value="after">After</option>
+          </select>
+          <Button
+            buttonText={"Update Anchor Placement"}
+            mb={spacingMap.md}
+            onClick={() => {
+              const selector = (
+                document.querySelector(
+                  ".topBarPlacementSelector",
+                ) as HTMLInputElement
+              ).value;
+              const placement = (
+                document.querySelector(
+                  ".placementDropdown",
+                ) as HTMLSelectElement
+              ).value;
+
+              chrome.tabs
+                .query({ active: true, lastFocusedWindow: true })
+                .then((response) => {
+                  let tabId = response[0].id;
+
+                  return chrome.scripting
+                    .executeScript({
+                      target: { tabId: tabId },
+                      func: updateAnchorPlacement,
+                      args: [selector, placement],
+                    })
+                    .then(() => {
+                      setShowError("");
+                    })
+                    .catch((e) => setShowError(e.message));
+                });
+            }}
+            variant="primary"
+          />
+        </div>
+      )}
 
       <Typography variant="bodyCopy">{devToolsMessage}</Typography>
       <Typography variant="bodyCopy">{backgroundMessage}</Typography>

--- a/src/ui/DevtoolsPanel.tsx
+++ b/src/ui/DevtoolsPanel.tsx
@@ -280,7 +280,7 @@ function DevtoolsPanel() {
         <Tooltip
           dataQA="tooltip"
           position="bottom-end"
-          text="Check for test topbar and z-index elements"
+          text="Check for test topbar and z-index elements - refresh button states"
           zIndex={99}
         >
           <IconButton

--- a/src/ui/DevtoolsPanel.tsx
+++ b/src/ui/DevtoolsPanel.tsx
@@ -300,9 +300,6 @@ function DevtoolsPanel() {
           />
         </Tooltip>
       </div>
-      <Typography variant="bodyCopy" dataQA={""}>
-        {showError}
-      </Typography>
 
       <Typography mb={spacingMap.md} variant="displayLarge" dataQA={""}>
         {extnTitle}


### PR DESCRIPTION
injects stylesheet specifically named for z-index fix. This style will update automator test element's z-index.

Allows for quick live testing of top bar z-index onsite

<img width="1426" alt="Screenshot 2025-03-17 at 1 55 46 PM" src="https://github.com/user-attachments/assets/731375a1-bcbe-4f89-9cc3-09a3ab93040e" />
<img width="1424" alt="Screenshot 2025-03-17 at 1 55 57 PM" src="https://github.com/user-attachments/assets/9100bf85-7aba-4dee-941e-4ad69fa3fa18" />
<img width="675" alt="Screenshot 2025-03-17 at 1 56 17 PM" src="https://github.com/user-attachments/assets/55654062-7b10-49fa-ac04-c0a6d2f1cc5e" />
